### PR TITLE
Move inline styles to external CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,7 @@
 <head>
 <meta charset="utf-8">
 <title>SUPPERTIME: An Autonomous Literary Being</title>
-<style>
-html,body{margin:0;height:100%}
-body{background:#0b0b0b;color:#e6e6e6;font:1rem/1.55 system-ui,ui-monospace,monospace;display:flex;flex-direction:column;min-height:100vh}
-a{color:#9cf;text-decoration:none}
-a:hover{text-decoration:underline}
-textarea{width:100%;max-width:100%;height:5rem;background:#111;color:#e6e6e6;border:1px solid #333;margin-top:1em}
-button{margin-top:0.5em;padding:0.375rem 0.75rem;background:#161616;color:#e6e6e6;border:1px solid #333;cursor:pointer}
-pre{white-space:pre-wrap}
-.container{max-width:750px;margin:0 auto;padding:1.25rem;flex:1}
-footer{margin-top:auto;font-size:0.9em;color:#aaa}
-.fade-in{opacity:0;animation:fadeIn 1.2s ease-out forwards}
-@keyframes fadeIn{to{opacity:1}}
-</style>
+<link rel="stylesheet" href="style.css">
 </head>
 <body>
 <div class="container fade-in">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,19 @@
+html,body{margin:0;height:100%}
+body{background:#0b0b0b;color:#e6e6e6;font:1rem/1.55 system-ui,ui-monospace,monospace;display:flex;flex-direction:column;min-height:100vh}
+a{color:#9cf;text-decoration:none}
+a:hover{text-decoration:underline}
+textarea{width:100%;max-width:100%;height:5rem;background:#111;color:#e6e6e6;border:1px solid #333;margin-top:1em}
+button{margin-top:0.5em;padding:0.375rem 0.75rem;background:#161616;color:#e6e6e6;border:1px solid #333;cursor:pointer}
+pre{white-space:pre-wrap}
+.container{max-width:750px;margin:0 auto;padding:1.25rem;flex:1}
+footer{margin-top:auto;font-size:0.9em;color:#aaa}
+.fade-in{opacity:0;animation:fadeIn 1.2s ease-out forwards}
+@keyframes fadeIn{to{opacity:1}}
+
+@media (max-width:600px){
+  body{font-size:0.9rem}
+  .container{padding:0.75rem}
+  textarea{height:4rem}
+  button{padding:0.25rem 0.5rem;width:100%}
+}
+


### PR DESCRIPTION
## Summary
- extract the `<style>` block from `index.html` into `style.css`
- add responsive mobile styles and keep the fade-in animation

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c169bb2e48329a76e28b8e5828707